### PR TITLE
Add support for `public/static` directory in Next 9.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = (nextConfig = {}) => ({
 
     // For workbox configurations:
     // https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin
-    const {
+    let {
       disable = options.dev,
       register = true,
       dest = distDir,

--- a/index.js
+++ b/index.js
@@ -159,6 +159,7 @@ module.exports = (nextConfig = {}) => ({
           importsDirectory: _dest,
           globDirectory: options.dir,
           globPatterns: [
+            'public/static/**/*',
             'static/**/*'
           ],
           modifyURLPrefix: {


### PR DESCRIPTION
Next is deprecating `/static` folder in favor of `/public/static` this adds support for that directory.

In a future change, we may want to support the `public` directory as a whole (as this change will only add support for `/public/static`).

See more info here: https://nextjs.org/blog/next-9-1#public-directory-support