### PR TITLE
fix[main]: define runtimeCaching as let variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,14 @@ module.exports = (nextConfig = {}) => ({
       skipWaiting = true,
       clientsClaim = true,
       cleanupOutdatedCaches = true,
-      runtimeCaching = defaultCache,
       additionalManifestEntries,
       ignoreURLParametersMatching = [],
       importScripts = [],
       publicExcludes = [],
       ...workbox
     } = pwa
+
+    let { runtimeCaching = defaultCache } = pwa
 
     if (typeof nextConfig.webpack === 'function') {
       config = nextConfig.webpack(config, options)


### PR DESCRIPTION
To be able to redefine the `runtimeCaching` prop should be defined as `let`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shadowwalker/next-pwa/21)
<!-- Reviewable:end -->
