### PR TITLE
Invalid additionalManifestEntries while building

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (nextConfig = {}) => ({
       skipWaiting = true,
       clientsClaim = true,
       cleanupOutdatedCaches = true,
-      additionalManifestEntries,
+      additionalManifestEntries = [],
       ignoreURLParametersMatching = [],
       importScripts = [],
       publicExcludes = [],
@@ -134,11 +134,9 @@ module.exports = (nextConfig = {}) => ({
       )
 
       // precache files in public folder
-      let manifestEntries = additionalManifestEntries
-      if (!Array.isArray(manifestEntries)) {
-        manifestEntries = globby
-          .sync(['**/*', '!workbox-*.js', '!workbox-*.js.map', '!worker-*.js', '!worker-*.js.map',
-            `!${sw.replace(/^\/+/, '')}`, `!${sw.replace(/^\/+/, '')}.map`].concat(publicExcludes), {
+      let manifestEntries = globby
+      .sync(['**/*', '!workbox-*.js', '!workbox-*.js.map', '!worker-*.js', '!worker-*.js.map',
+        `!${sw.replace(/^\/+/, '')}`, `!${sw.replace(/^\/+/, '')}.map`].concat(publicExcludes), {
             cwd: 'public'
           })
           .map(f => ({
@@ -146,7 +144,9 @@ module.exports = (nextConfig = {}) => ({
             revision: getRevision(`public/${f}`)
           }))
         manifestEntries.push({ url: '/', revision: buildId })
-      }
+
+      // Add additional manifest entries
+      additionalManifestEntries.forEach((url) => manifestEntries.push({ url, revision: buildId }))
 
       const prefix = config.output.publicPath ? `${config.output.publicPath}static/` : 'static/'
       const workboxCommon = {


### PR DESCRIPTION
as of now if `additionalManifestEntries` are provided `sw.js` output was like below that is invalid hence service worker file becomes invalid

![image](https://user-images.githubusercontent.com/5774849/78840468-7c36ee80-7a18-11ea-945a-1b9802709c0b.png)

this PR fixes the generated `sw.js` output fix this issue

![image](https://user-images.githubusercontent.com/5774849/78840642-ee0f3800-7a18-11ea-9826-54e821686d83.png)
