### PR TITLE
Add subdomain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ module.exports = withPWA({
 - publicExcludes - array of glob pattern strings to excludes files in `public` folder being precached.
   - default: `[]` - i.e. default behavior will precache all the files inside your `public` folder
   - example: `['!img/super-large-image.jpg', '!fonts/not-used-fonts.otf']`
+- cdnPrefix: string - url prefix to allow hosting static files on cdn
+  - default: `""` - i.e. default with no prefix
+  - example: `/subdomain` if the app is hosted on `somehost.com/subdoamin`
 
 ### Other Options
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ module.exports = withPWA({
   - example: `['!img/super-large-image.jpg', '!fonts/not-used-fonts.otf']`
 - subdomainPrefix: string - url prefix to allow hosting static files on a subdomain
   - default: `""` - i.e. default with no prefix
-  - example: `/subdomain` if the app is hosted on `example.com/subdoamin`
+  - example: `/subdomain` if the app is hosted on `example.com/subdomain`
 
 ### Other Options
 

--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ module.exports = withPWA({
 - publicExcludes - array of glob pattern strings to excludes files in `public` folder being precached.
   - default: `[]` - i.e. default behavior will precache all the files inside your `public` folder
   - example: `['!img/super-large-image.jpg', '!fonts/not-used-fonts.otf']`
-- cdnPrefix: string - url prefix to allow hosting static files on cdn
+- subdomainPrefix: string - url prefix to allow hosting static files on a subdomain
   - default: `""` - i.e. default with no prefix
-  - example: `/subdomain` if the app is hosted on `somehost.com/subdoamin`
+  - example: `/subdomain` if the app is hosted on `example.com/subdoamin`
 
 ### Other Options
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = (nextConfig = {}) => ({
       register = true,
       dest = distDir,
       sw = 'sw.js',
+      cdnPrefix = '',
       scope = '/',
       skipWaiting = true,
       clientsClaim = true,
@@ -56,8 +57,8 @@ module.exports = (nextConfig = {}) => ({
     
     config.plugins.push(
       new webpack.DefinePlugin({
-        __PWA_SW__: `"${_sw}"`,
-        __PWA_SCOPE__: `"${scope}"`,
+        __PWA_SW__: `"${path.join(cdnPrefix, _sw)}"`,
+        __PWA_SCOPE__: `"${path.join(cdnPrefix, scope)}"`,
         __PWA_ENABLE_REGISTER__: `${Boolean(register)}`
       })
     )
@@ -88,8 +89,8 @@ module.exports = (nextConfig = {}) => ({
       const _dest = path.join(options.dir, dest)
 
       console.log(`> [PWA] Service worker: ${path.join(_dest, sw)}`)
-      console.log(`> [PWA]   url: ${_sw}`)
-      console.log(`> [PWA]   scope: ${scope}`)
+      console.log(`> [PWA]   url: ${path.join(cdnPrefix, _sw)}`)
+      console.log(`> [PWA]   scope: ${path.join(cdnPrefix, scope)}`)
 
       // build custom worker
       let customWorkerEntry = path.join(options.dir, 'worker', 'index.js')
@@ -142,10 +143,10 @@ module.exports = (nextConfig = {}) => ({
             cwd: 'public'
           })
           .map(f => ({
-            url: `/${f}`,
+            url: path.join(cdnPrefix,`/${f}`),
             revision: getRevision(`public/${f}`)
           }))
-        manifestEntries.push({ url: '/', revision: buildId })
+        manifestEntries.push({ url: path.join(cdnPrefix, '/'), revision: buildId })
       }
 
       const prefix = config.output.publicPath ? `${config.output.publicPath}static/` : 'static/'
@@ -164,7 +165,7 @@ module.exports = (nextConfig = {}) => ({
           }
         ],
         modifyURLPrefix: {
-          [prefix]: '/_next/static/'
+          [prefix]: path.join(cdnPrefix, '/_next/static/')
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = (nextConfig = {}) => ({
       register = true,
       dest = distDir,
       sw = 'sw.js',
-      cdnPrefix = '',
+      subdomainPrefix = '',
       scope = '/',
       skipWaiting = true,
       clientsClaim = true,
@@ -57,8 +57,8 @@ module.exports = (nextConfig = {}) => ({
     
     config.plugins.push(
       new webpack.DefinePlugin({
-        __PWA_SW__: `"${path.join(cdnPrefix, _sw)}"`,
-        __PWA_SCOPE__: `"${path.join(cdnPrefix, scope)}"`,
+        __PWA_SW__: `"${path.join(subdomainPrefix, _sw)}"`,
+        __PWA_SCOPE__: `"${path.join(subdomainPrefix, scope)}"`,
         __PWA_ENABLE_REGISTER__: `${Boolean(register)}`
       })
     )
@@ -89,8 +89,8 @@ module.exports = (nextConfig = {}) => ({
       const _dest = path.join(options.dir, dest)
 
       console.log(`> [PWA] Service worker: ${path.join(_dest, sw)}`)
-      console.log(`> [PWA]   url: ${path.join(cdnPrefix, _sw)}`)
-      console.log(`> [PWA]   scope: ${path.join(cdnPrefix, scope)}`)
+      console.log(`> [PWA]   url: ${path.join(subdomainPrefix, _sw)}`)
+      console.log(`> [PWA]   scope: ${path.join(subdomainPrefix, scope)}`)
 
       // build custom worker
       let customWorkerEntry = path.join(options.dir, 'worker', 'index.js')
@@ -143,10 +143,10 @@ module.exports = (nextConfig = {}) => ({
             cwd: 'public'
           })
           .map(f => ({
-            url: path.join(cdnPrefix,`/${f}`),
+            url: path.join(subdomainPrefix,`/${f}`),
             revision: getRevision(`public/${f}`)
           }))
-        manifestEntries.push({ url: path.join(cdnPrefix, '/'), revision: buildId })
+        manifestEntries.push({ url: path.join(subdomainPrefix, '/'), revision: buildId })
       }
 
       const prefix = config.output.publicPath ? `${config.output.publicPath}static/` : 'static/'
@@ -165,7 +165,7 @@ module.exports = (nextConfig = {}) => ({
           }
         ],
         modifyURLPrefix: {
-          [prefix]: path.join(cdnPrefix, '/_next/static/')
+          [prefix]: path.join(subdomainPrefix, '/_next/static/')
         }
       }
 


### PR DESCRIPTION
added `subdomainPrefix` to support an app hosted on a subdomain

This is to correct the inappropriate naming in this pull request: https://github.com/shadowwalker/next-pwa/pull/31

a working example github pages with pwa (after locally modified next-pwa package): https://project-setup.github.io/github_pwa/
my pwa setup for the project: https://github.com/Project-Setup/github_pwa#pwa
