### PR TITLE
Change getRevision to use file content not name

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const WorkboxPlugin = require('workbox-webpack-plugin')
 const defaultCache = require('./cache')
 
-const getRevision = file => crypto.createHash('md5').update(Buffer.from(file)).digest('hex')
+const getRevision = file => crypto.createHash('md5').update(fs.readFileSync(file)).digest('hex')
 
 module.exports = (nextConfig = {}) => ({
   ...nextConfig,


### PR DESCRIPTION
Currently getRevision uses the file name instead of the file content to calculate the md5. This causes the revision in the sw.js manifest to always remain the same which in itself makes the cache not work as expected when there are changes in the file.

Closes #59 