### PR TITLE
Add precache home page as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ module.exports = withPWA({
 - subdomainPrefix: string - url prefix to allow hosting static files on a subdomain
   - default: `""` - i.e. default with no prefix
   - example: `/subdomain` if the app is hosted on `example.com/subdomain`
+- precacheHomePage: boolean - whether or not the pwa should precache the home page.
+  - default: `true` - i.e. it will precache the `/` page by default.
+  - example: `false` the home page won't be precached.
 
 ### Other Options
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = (nextConfig = {}) => ({
       importScripts = [],
       publicExcludes = [],
       manifestTransforms = [],
-      precacheHomePage = false,
+      precacheHomePage = true,
       ...workbox
     } = pwa
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = (nextConfig = {}) => ({
       importScripts = [],
       publicExcludes = [],
       manifestTransforms = [],
+      precacheHomePage = false,
       ...workbox
     } = pwa
 
@@ -147,7 +148,10 @@ module.exports = (nextConfig = {}) => ({
             url: path.posix.join(subdomainPrefix,`/${f}`),
             revision: getRevision(`public/${f}`)
           }))
-        manifestEntries.push({ url: path.posix.join(subdomainPrefix, '/'), revision: buildId })
+        
+        if (precacheHomePage) {
+          manifestEntries.push({ url: path.posix.join(subdomainPrefix, '/'), revision: buildId })
+        }
       }
 
       const prefix = config.output.publicPath ? `${config.output.publicPath}static/` : 'static/'


### PR DESCRIPTION
As mentioned in this [comment](https://github.com/shadowwalker/next-pwa/issues/64#issuecomment-645711907), sometimes there are some issues when precaching the home page. So, imo it would be good to set this home page precaching as an optional parameter for next-pwa.

If the user does not want to pre-cache it, now there's this optional param available.