### PR TITLE
Fix bug in the Cache.js

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -101,8 +101,8 @@ module.exports = [
       expiration: {
         maxEntries: 32,
         maxAgeSeconds: 24 * 60 * 60 // 24 hours
-      }
+      },
+      networkTimeoutSeconds: 10
     },
-    networkTimeoutSeconds: 10
   }
 ]


### PR DESCRIPTION
I get this error when try to use next-pwa.
```
Failed to compile.                                                                                                                                      
                                                                                                                                                        
Please check your GenerateSW plugin configuration:                                                                                                      
child "runtimeCaching" fails because ["runtimeCaching" at position 8 fails because ["networkTimeoutSeconds" is not a supported parameter.]]
```