### PR TITLE
Rewrite activated event listener to ES5

### DIFF
--- a/register.js
+++ b/register.js
@@ -3,12 +3,13 @@ import { Workbox } from 'workbox-window'
 if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
   window.workbox = new Workbox(__PWA_SW__, { scope: __PWA_SCOPE__ })
   
-  window.workbox.addEventListener('activated', async event => {
+  window.workbox.addEventListener('activated', function(event) {
     if (!event.isUpdate) {
-      const c = await caches.keys()
-      if (!c.includes('start-url')) {
-        fetch(__PWA_START_URL__)
-      }
+      caches.keys().then(function(c) {
+        if (!c.includes('start-url')) {
+          fetch(__PWA_START_URL__)
+        }
+      });
     }
   })
 


### PR DESCRIPTION
The register.js is included in main.js and is not transpiled to target ES version. This causes IE to fail during parsing.
Rewrote the activated event listener to use ES5 syntax