### PR TITLE
docs: remove font from example head meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ Add the following into `_document.jsx` or `_document.tsx`, in `<Head>`:
 <link rel='manifest' href='/static/manifest.json' />
 <link rel='mask-icon' href='/static/icons/safari-pinned-tab.svg' color='#5bbad5' />
 <link rel='shortcut icon' href='/static/icons/favicon.ico' />
-<link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:300,400,500' />
      
 <meta name='twitter:card' content='summary' />
 <meta name='twitter:url' content='https://yourdomain.com' />


### PR DESCRIPTION
Is there a PWA-related function for the font in the example head meta in the readme? Otherwise maybe better to keep it out to prevent inadvertent copy/paste and unneeded font downloads.