### PR TITLE
Cleaner "Offer a page reload for users" recipe

### DIFF
--- a/examples/lifecycle/pages/index.js
+++ b/examples/lifecycle/pages/index.js
@@ -37,7 +37,7 @@ export default () => {
           })
 
           // Send a message to the waiting service worker, instructing it to activate.
-          wb.messageSW({ type: 'SKIP_WAITING' })
+          wb.messageSkipWaiting()
         } else {
           console.log(
             'User rejected to reload the web app, keep using old version. New version will be automatically load when user open the app next time.'
@@ -46,7 +46,6 @@ export default () => {
       }
 
       wb.addEventListener('waiting', promptNewVersionAvailable)
-      wb.addEventListener('externalwaiting', promptNewVersionAvailable)
 
       // ISSUE - this is not working as expected, why?
       // I could only make message event listenser work when I manually add this listenser into sw.js file


### PR DESCRIPTION
Since Workbox v6, a new method `messageSkipWaiting()` has been added to the `workbox-window` module to simplify the process of telling the "waiting" service worker to activate. And all "external" events in `workbox-window` have been removed in place of "normal" events with an `isExternal` property set to `true`. Thanks to both of the above changes, the "Offer a page reload for users" recipe can be simplified.

https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v5