### PR TITLE
Fix undefined variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = (nextConfig = {}) => ({
     console.log(`> [PWA] Compile ${options.isServer ? 'server' : 'client (static)'}`)
 
     // inject register script to main.js
-    const _sw = path.posix.join(basePath, sw.startsWith('/') ? _sw : `/${sw}`)
+    const _sw = path.posix.join(basePath, sw.startsWith('/') ? sw : `/${sw}`)
     config.plugins.push(
       new webpack.DefinePlugin({
         __PWA_SW__: `'${_sw}'`,


### PR DESCRIPTION
Regression from c6416215bcdec6cc49540259f47863f14ea8f39d

`next build` will fail if you include next-pwa 5.1.0.

```console
$ next build
info  - Using webpack 5. Reason: future.webpack5 option enabled https://nextjs.org/docs/messages/webpack5
warn  - You have enabled experimental feature(s).
warn  - Experimental features are not covered by semver, and may cause unexpected or broken application behavior. Use them at your own risk.
info  - Checking validity of types...
info  - Creating an optimized production build...
> [PWA] Compile client (static)
> Build error occurred
10:00:21.312  	ReferenceError: Cannot access '_sw' before initialization
    at Object.webpack (/vercel/workpath0/node_modules/next-pwa/index.js:84:64)
    at getBaseWebpackConfig (/vercel/workpath0/node_modules/next/dist/build/webpack-config.js:145:412)
    at async Promise.all (index 0)
    at async Span.traceAsyncFn (/vercel/workpath0/node_modules/next/dist/telemetry/trace/trace.js:5:584)
    at async /vercel/workpath0/node_modules/next/dist/build/index.js:11:960
    at async Span.traceAsyncFn (/vercel/workpath0/node_modules/next/dist/telemetry/trace/trace.js:5:584)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```