### PR TITLE
split the google-fonts strategies

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -3,16 +3,27 @@
 // Workbox RuntimeCaching config: https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.RuntimeCachingEntry
 module.exports = [
   {
-    urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
+    urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
     handler: 'CacheFirst',
     options: {
-      cacheName: 'google-fonts',
+      cacheName: 'google-fonts-webfonts',
       expiration: {
         maxEntries: 4,
-        maxAgeSeconds: 365 * 24 * 60 * 60 // 365 days
-      }
-    }
+        maxAgeSeconds: 365 * 24 * 60 * 60, // 365 days
+      },
+    },
   },
+  {
+    urlPattern: /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'google-fonts-stylesheets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
+      },
+    },
+  }
   {
     urlPattern: /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
     handler: 'StaleWhileRevalidate',

--- a/examples/lifecycle/next.config.js
+++ b/examples/lifecycle/next.config.js
@@ -1,14 +1,9 @@
 const withPWA = require('next-pwa')
 
-// change start-url cache strategy, so that we can prompt user to reload when
-// new version available, instead of showing new version directly
-const runtimeCaching = require('next-pwa/cache')
-
 module.exports = withPWA({
   pwa: {
     dest: 'public',
     register: false,
-    skipWaiting: false,
-    runtimeCaching
+    skipWaiting: false
   }
 })

--- a/examples/lifecycle/next.config.js
+++ b/examples/lifecycle/next.config.js
@@ -3,7 +3,6 @@ const withPWA = require('next-pwa')
 // change start-url cache strategy, so that we can prompt user to reload when
 // new version available, instead of showing new version directly
 const runtimeCaching = require('next-pwa/cache')
-runtimeCaching[0].handler = 'StaleWhileRevalidate'
 
 module.exports = withPWA({
   pwa: {


### PR DESCRIPTION
First off, I'd like to say that this is an amazing repo. 

I thought it would be a good idea to split the google font strategies so that we can have 1 for the style sheets & another for the font files themselves which don't change.

Ive based this PR off of this article https://developers.google.com/web/tools/workbox/guides/common-recipes#google_fonts

Let me know what you think, thanks 