### PR TITLE
fix: invalid dynamic nav url on cache

### DIFF
--- a/register.js
+++ b/register.js
@@ -60,13 +60,13 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
     const pushState = history.pushState
     history.pushState = function () {
       pushState.apply(history, arguments)
-      cacheOnFrontEndNav(arguments[0].url)
+      cacheOnFrontEndNav(arguments[0].as || arguments[0].url)
     }
 
     const replaceState = history.replaceState
     history.replaceState = function () {
       replaceState.apply(history, arguments)
-      cacheOnFrontEndNav(arguments[0].url)
+      cacheOnFrontEndNav(arguments[0].as || arguments[0].url)
     }
 
     window.addEventListener('online', () => {

--- a/register.js
+++ b/register.js
@@ -60,13 +60,13 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
     const pushState = history.pushState
     history.pushState = function () {
       pushState.apply(history, arguments)
-      cacheOnFrontEndNav(arguments[0].as || arguments[0].url)
+      cacheOnFrontEndNav(arguments[2])
     }
 
     const replaceState = history.replaceState
     history.replaceState = function () {
       replaceState.apply(history, arguments)
-      cacheOnFrontEndNav(arguments[0].as || arguments[0].url)
+      cacheOnFrontEndNav(arguments[2])
     }
 
     window.addEventListener('online', () => {


### PR DESCRIPTION
I am experimenting with `cacheOnFrontendNav`. I got the following results when using it in combination with dynamic pages (e.g. `./pages/[...uid].tsx`).

I don't know if this current change is the best way to do it. I don't know where to find documentation on the `arguments` array. It seems like the third array item is always correct. Haven't tested with query strings (not sure if this matters)

![image](https://user-images.githubusercontent.com/20819332/116792869-ad6eda80-aac3-11eb-9669-d466ae30c7ae.png)

