### PR TITLE
Add node builtins fallback entries in webpack config

### DIFF
--- a/build-custom-worker.js
+++ b/build-custom-worker.js
@@ -34,7 +34,22 @@ const buildCustomWorker = ({ id, basedir, destdir, plugins, success, minify }) =
       main: customWorkerEntry
     },
     resolve: {
-      extensions: ['.ts', '.js']
+      extensions: ['.ts', '.js'],
+      fallback: {
+        module: false,
+        dgram: false,
+        dns: false,
+        path: false,
+        fs: false,
+        os: false,
+        crypto: false,
+        stream: false,
+        http2: false,
+        net: false,
+        tls: false,
+        zlib: false,
+        child_process: false
+      }
     },
     module: {
       rules: [

--- a/build-fallback-worker.js
+++ b/build-fallback-worker.js
@@ -68,7 +68,22 @@ const buildFallbackWorker = ({ id, fallbacks, basedir, destdir, success, minify 
       main: fallbackJs
     },
     resolve: {
-      extensions: ['.js']
+      extensions: ['.js'],
+      fallback: {
+        module: false,
+        dgram: false,
+        dns: false,
+        path: false,
+        fs: false,
+        os: false,
+        crypto: false,
+        stream: false,
+        http2: false,
+        net: false,
+        tls: false,
+        zlib: false,
+        child_process: false
+      }
     },
     module: {
       rules: [


### PR DESCRIPTION
These settings are more sensible. Without them my PWA with a custom worker fails to build, because it has dependencies who have dependencies that are universal modules that use some nodeJS builtins when they are available. 