### PR TITLE
Update instructions to use `public` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ app.prepare()
 
 ### Step 2: Add Manifest File (Example)
 
-Create a `manifest.json` file in your `static` folder:
+Create a `manifest.json` file in your `public` folder:
 
 ```json
 {
@@ -114,18 +114,18 @@ Create a `manifest.json` file in your `static` folder:
   "short_name": "App",
   "icons": [
     {
-      "src": "/static/icons/android-chrome-192x192.png",
+      "src": "/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/static/icons/android-chrome-384x384.png",
+      "src": "/icons/android-chrome-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "/static/icons/icon-512x512.png",
+      "src": "/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
@@ -150,20 +150,20 @@ Add the following into `_document.jsx` or `_document.tsx`, in `<Head>`:
 <meta name='description' content='Best PWA App in the world' />
 <meta name='format-detection' content='telephone=no' />
 <meta name='mobile-web-app-capable' content='yes' />
-<meta name='msapplication-config' content='/static/icons/browserconfig.xml' />
+<meta name='msapplication-config' content='/icons/browserconfig.xml' />
 <meta name='msapplication-TileColor' content='#2B5797' />
 <meta name='msapplication-tap-highlight' content='no' />
 <meta name='theme-color' content='#000000' />
 
-<link rel='apple-touch-icon' href='/static/icons/touch-icon-iphone.png' />
-<link rel='apple-touch-icon' sizes='152x152' href='/static/icons/touch-icon-ipad.png' />
-<link rel='apple-touch-icon' sizes='180x180' href='/static/icons/touch-icon-iphone-retina.png' />
-<link rel='apple-touch-icon' sizes='167x167' href='/static/icons/touch-icon-ipad-retina.png' />
+<link rel='apple-touch-icon' href='/icons/touch-icon-iphone.png' />
+<link rel='apple-touch-icon' sizes='152x152' href='/icons/touch-icon-ipad.png' />
+<link rel='apple-touch-icon' sizes='180x180' href='/icons/touch-icon-iphone-retina.png' />
+<link rel='apple-touch-icon' sizes='167x167' href='/icons/touch-icon-ipad-retina.png' />
 
-<link rel='icon' type='image/png' sizes='32x32' href='/static/icons/favicon-32x32.png' />
-<link rel='icon' type='image/png' sizes='16x16' href='/static/icons/favicon-16x16.png' />
-<link rel='manifest' href='/static/manifest.json' />
-<link rel='mask-icon' href='/static/icons/safari-pinned-tab.svg' color='#5bbad5' />
+<link rel='icon' type='image/png' sizes='32x32' href='/icons/favicon-32x32.png' />
+<link rel='icon' type='image/png' sizes='16x16' href='/icons/favicon-16x16.png' />
+<link rel='manifest' href='/manifest.json' />
+<link rel='mask-icon' href='/icons/safari-pinned-tab.svg' color='#5bbad5' />
 <link rel='shortcut icon' href='/favicon.ico' />
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Roboto:300,400,500' />
      
@@ -171,24 +171,24 @@ Add the following into `_document.jsx` or `_document.tsx`, in `<Head>`:
 <meta name='twitter:url' content='https://yourdomain.com' />
 <meta name='twitter:title' content='PWA App' />
 <meta name='twitter:description' content='Best PWA App in the world' />
-<meta name='twitter:image' content='https://yourdomain.com/static/icons/android-chrome-192x192.png' />
+<meta name='twitter:image' content='https://yourdomain.com/icons/android-chrome-192x192.png' />
 <meta name='twitter:creator' content='@DavidWShadow' />
 <meta property='og:type' content='website' />
 <meta property='og:title' content='PWA App' />
 <meta property='og:description' content='Best PWA App in the world' />
 <meta property='og:site_name' content='PWA App' />
 <meta property='og:url' content='https://yourdomain.com' />
-<meta property='og:image' content='https://yourdomain.com/static/icons/apple-touch-icon.png' />
+<meta property='og:image' content='https://yourdomain.com/icons/apple-touch-icon.png' />
 
 <!-- apple splash screen images -->
 <!--
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_2048.png' sizes='2048x2732' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_1668.png' sizes='1668x2224' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_1536.png' sizes='1536x2048' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_1125.png' sizes='1125x2436' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_1242.png' sizes='1242x2208' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_750.png' sizes='750x1334' />
-<link rel='apple-touch-startup-image' href='/static/images/apple_splash_640.png' sizes='640x1136' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_2048.png' sizes='2048x2732' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_1668.png' sizes='1668x2224' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_1536.png' sizes='1536x2048' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_1125.png' sizes='1125x2436' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_1242.png' sizes='1242x2208' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_750.png' sizes='750x1334' />
+<link rel='apple-touch-startup-image' href='/images/apple_splash_640.png' sizes='640x1136' />
 -->
 ```
 


### PR DESCRIPTION
Hello! First of all, thanks for this integration, really cool!

Since a few versions, Next.js has used the `public` folder - probably not necessary to keep the docs for the `static` folder in the readme anymore.