### PR TITLE
Fixed getFallbackEnvs pageExtensions param undefined

### DIFF
--- a/build-fallback-worker.js
+++ b/build-fallback-worker.js
@@ -6,7 +6,7 @@ const webpack = require('webpack')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 
-const getFallbackEnvs = ({fallbacks, basedir, id}) => {
+const getFallbackEnvs = ({fallbacks, basedir, id, pageExtensions}) => {
   let { document, data } = fallbacks
 
   if (!document) {


### PR DESCRIPTION
## Vercel Logs without this update:
![image](https://user-images.githubusercontent.com/6491925/129518581-f34be155-5a9a-4e69-8e7e-0b77c9f2d1ed.png)

## Local logs with adjustment:
![image](https://user-images.githubusercontent.com/6491925/129518772-4d41f084-7e78-4b05-8255-7f14bfcc83dd.png)
