### PR TITLE
Add custom worker directory config

### DIFF
--- a/build-custom-worker.js
+++ b/build-custom-worker.js
@@ -6,13 +6,13 @@ const webpack = require('webpack')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 
-const buildCustomWorker = ({ id, basedir, destdir, plugins, success, minify }) => {
+const buildCustomWorker = ({ id, basedir, customWorkerDir, destdir, plugins, success, minify }) => {
   let workerDir = undefined
 
-  if (fs.existsSync(path.join(basedir, 'worker'))) {
-    workerDir = path.join(basedir, 'worker')
-  } else if (fs.existsSync(path.join(basedir, 'src', 'worker'))) {
-    workerDir = path.join(basedir, 'src', 'worker')
+  if (fs.existsSync(path.join(basedir, customWorkerDir))) {
+    workerDir = path.join(basedir, customWorkerDir)
+  } else if (fs.existsSync(path.join(basedir, 'src', customWorkerDir))) {
+    workerDir = path.join(basedir, 'src', customWorkerDir)
   }
 
   if (!workerDir) return

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ module.exports = (nextConfig = {}) => ({
       cacheOnFrontEndNav = false,
       reloadOnOnline = true,
       scope = basePath,
+      customWorkerDir = 'worker',
       subdomainPrefix,  // deprecated, use basePath in next.config.js instead
       ...workbox
     } = pwa
@@ -98,6 +99,7 @@ module.exports = (nextConfig = {}) => ({
       buildCustomWorker({
         id: buildId,
         basedir: options.dir,
+        customWorkerDir,
         destdir: _dest,
         plugins: config.plugins.filter(plugin => plugin instanceof webpack.DefinePlugin),
         success: ({name}) => importScripts.unshift(name),


### PR DESCRIPTION
This is a great plugin!

I'm using a custom Service Worker in combination with Web Workers, which makes my folder structure a bit confusing as the custom SW folder has to be named `worker`.

I added a config setting `customWorkerDir` to configure the name of the folder containing the custom worker with fallback to the previous default. 