### PR TITLE
Introduce an cacheStartUrl configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = (nextConfig = {}) => ({
       sw = 'sw.js',
       dynamicStartUrl = true,
       dynamicStartUrlRedirect,
+      cacheStartUrl = true,
       skipWaiting = true,
       clientsClaim = true,
       cleanupOutdatedCaches = true,
@@ -154,16 +155,18 @@ module.exports = (nextConfig = {}) => ({
           }))
       }
 
-      if (!dynamicStartUrl) {
-        manifestEntries.push({
-          url: basePath,
-          revision: buildId
-        })
-      } else if (typeof dynamicStartUrlRedirect === 'string' && dynamicStartUrlRedirect.length > 0) {
-        manifestEntries.push({
-          url: dynamicStartUrlRedirect,
-          revision: buildId
-        })
+      if (cacheStartUrl) {
+        if (!dynamicStartUrl) {
+          manifestEntries.push({
+            url: basePath,
+            revision: buildId
+          })
+        } else if (typeof dynamicStartUrlRedirect === 'string' && dynamicStartUrlRedirect.length > 0) {
+          manifestEntries.push({
+            url: dynamicStartUrlRedirect,
+            revision: buildId
+          })
+        }
       }
 
       let _fallbacks = fallbacks


### PR DESCRIPTION
With cacheStartUrl users can decide if they want to cache or not startUrl. It is the same as dynamicStartUrl but with dynamicStartUrl serviceWorker will send a request extra.