### PR TITLE
Fix middleware-manifest.json.json error

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = (nextConfig = {}) => ({
         additionalManifestEntries: dev ? [] : manifestEntries,
         exclude: [
           ({ asset, compilation }) => {
-            if (asset.name.match(/^(build-manifest\.json|react-loadable-manifest\.json|middleware-manifest\.json)$/)) {
+            if (asset.name.match(/^(build-manifest\.json|react-loadable-manifest\.json|server\/middleware-manifest\.json)$/)) {
               return true
             }
             if (dev && !asset.name.startsWith('static/runtime/')) {


### PR DESCRIPTION
Even after the update the middleware-manifest.json.json error was there. As it was in the server folder, the file name didn't match with the path.  So I just replace the filename ("middleware-manifest\.json") with the route ("server\/middleware-manifest\.json"). It fixed the problem (at least for me).