### PR TITLE
fix double // for precache in static/media

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,6 +222,7 @@ module.exports = (nextConfig = {}) => ({
           async (manifestEntries, compilation) => {
             const manifest = manifestEntries.map(m => {
               m.url = m.url.replace('/_next//static/image', '/_next/static/image')
+              m.url = m.url.replace('/_next//static/media', '/_next/static/media')
               m.url = m.url.replace(/\[/g, '%5B').replace(/\]/g, '%5D')
               m.revision = buildId
               return m


### PR DESCRIPTION
Fixes the same issue as [#231](https://github.com/shadowwalker/next-pwa/issues/231)

All static media files are served from the `media` folder (this was changed in Next.js in https://github.com/vercel/next.js/pull/30168)