### PR TITLE
fixed buildExcludes options not working 

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = (nextConfig = {}) => ({
     }
 
     console.log(`> [PWA] Compile ${options.isServer ? 'server' : 'client (static)'}`)
-    
+
     let { runtimeCaching = defaultCache } = pwa
     const _scope = path.posix.join(scope, '/')
 
@@ -194,6 +194,7 @@ module.exports = (nextConfig = {}) => ({
         swDest: path.join(_dest, sw),
         additionalManifestEntries: dev ? [] : manifestEntries,
         exclude: [
+          ...buildExcludes
           ({ asset, compilation }) => {
             if (asset.name.match(/^(build-manifest\.json|react-loadable-manifest\.json|server\/middleware-manifest\.json|server\/middleware-runtime\.js|_middleware\.js|server\/pages\/_middleware\.js)$/)) {
               return true
@@ -210,8 +211,7 @@ module.exports = (nextConfig = {}) => ({
               }
             }
             return false
-          },
-          ...buildExcludes
+          }
         ],
         modifyURLPrefix: {
           ...modifyURLPrefix,


### PR DESCRIPTION

Fixed `buildExcludes` option not working at all

Here are some source code, 

#### next-pwa
``` javascript
exclude: [
  ({ asset, compilation }) => {
    if (asset.name.match(/^(build-manifest\.json|react-loadable-manifest\.json|server\/middleware-manifest\.json|server\/middleware-runtime\.js|_middleware\.js|server\/pages\/_middleware\.js)$/)) {
      return true
    }
    .....
    return false
  },
  ...buildExcludes
]
```

`exclude` options first element is function type, when pass to `workbox-webpack-plugin` apply checkCondition function. it always match first `if` condition. so that your `buildExcludes` with some string strategy or regex strategy will not match at all. on the other words `buildExcludes` not effect.

below is `workbox-webpack-plugin` source code

```typescript
function checkConditions(asset, compilation, conditions = []) {
    for (const condition of conditions) {
        if (typeof condition === 'function') {
            return condition({ asset, compilation });
            //return compilation !== null;
        }
        else {
            if (webpack_1.ModuleFilenameHelpers.matchPart(asset.name, condition)) {
                return true;
            }
        }
    }
    // We'll only get here if none of the conditions applied.
    return false;
}
```
