### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Create a `manifest.json` file in your `public` folder:
 
 ### Step 3: Add Head Meta (Example)
 
-Add the following into `_document.jsx` or `_document.tsx`, in `<Head>`:
+Add the following into `_document.jsx` or `_app.tsx`, in `<Head>`:
 
 ``` html
 <meta name='application-name' content='PWA App' />


### PR DESCRIPTION
Small documentation change.

`_document.tsx` appears twice in step 3. It should be:
> `_document.jsx` or `_app.tsx`
