### PR TITLE
Update workbox link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zero Config [PWA](https://developers.google.com/web/progressive-web-apps/) Plugin for [Next.js](https://nextjs.org/)
 
-This plugin is powered by [workbox](https://developers.google.com/web/tools/workbox/) and other good stuff.
+This plugin is powered by [workbox](https://developer.chrome.com/docs/workbox/) and other good stuff.
 
 ![size](https://img.shields.io/bundlephobia/minzip/next-pwa.svg) ![dependencies](https://img.shields.io/librariesio/release/npm/next-pwa) ![downloads](https://img.shields.io/npm/dw/next-pwa.svg) ![license](https://img.shields.io/npm/l/next-pwa.svg)
 


### PR DESCRIPTION
Cheers

I just saw that when clicking the workbox link in the readme it leads to the "old" (legacy) verison of the workbox documentation.

They link to the new documentation in the (light blue) banner on their website:

<img width="1298" alt="Screenshot 2022-05-16 at 09 13 25" src="https://user-images.githubusercontent.com/49987425/168538782-5259e40f-44ef-4caa-85f2-ccf12dd9a666.png">
 
This PR fixes the readme to point to the new documentation directly.