### PR TITLE
PWA doc migrated to web.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zero Config [PWA](https://developers.google.com/web/progressive-web-apps/) Plugin for [Next.js](https://nextjs.org/)
+# Zero Config [PWA](https://web.dev/learn/pwa/) Plugin for [Next.js](https://nextjs.org/)
 
 This plugin is powered by [workbox](https://developer.chrome.com/docs/workbox/) and other good stuff.
 


### PR DESCRIPTION
PWA url has migrated from [https://developers.google.com/](https://developers.google.com/web/ilt?hl=BG) to https://web.dev/learn/pwa/. Fixing the url in README.