### PR TITLE
Allows all PWA options to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = (nextConfig = {}) => {
         webpack,
         buildId,
         dev,
-        config: { distDir = '.next', pwa = {}, pageExtensions = ['tsx', 'ts', 'jsx', 'js', 'mdx'], experimental = {} }
+        config: { distDir = '.next', pwa = nextConfig.pwa, pageExtensions = ['tsx', 'ts', 'jsx', 'js', 'mdx'], experimental = {} }
       } = options
 
       let basePath = options.config.basePath


### PR DESCRIPTION
In release 5.5.5 the disable option was broken. This fixes the option and allows it to work again.
Edit: Turns out all of the options specified do not work in 5.5.5. This should fix this.
Resolves: #371
Resolves: #370 
Resolves: #378