### PR TITLE
register SW when using next@13 app directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,11 @@ module.exports =
               entries['main.js'].unshift(registerJs)
             }
             if (entries['main-app'] && !entries['main-app'].includes(registerJs)) {
-              entries['main-app'].unshift(registerJs)
+              if (Array.isArray(entries['main-app'])) {
+                entries['main-app'].unshift(registerJs)
+              } else if (typeof entries['main-app'] === 'string') {
+                entries['main-app'] = [registerJs, entries['main-app']]
+              }
             }
             return entries
           })

--- a/index.js
+++ b/index.js
@@ -96,6 +96,9 @@ module.exports =
             if (entries['main.js'] && !entries['main.js'].includes(registerJs)) {
               entries['main.js'].unshift(registerJs)
             }
+            if (entries['main-app'] && !entries['main-app'].includes(registerJs)) {
+              entries['main-app'].unshift(registerJs)
+            }
             return entries
           })
 


### PR DESCRIPTION
When using the new `app` directory in Next 13 a new main JS entrypoint is introduced, causing the PWA not to be installed.
This PR also adds the register code to the Next 13 app entry point.