### PR TITLE
register SW when using next@13.1 app directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,13 @@ module.exports =
             if (entries['main.js'] && !entries['main.js'].includes(registerJs)) {
               entries['main.js'].unshift(registerJs)
             }
+            if (entries['main-app'] && !entries['main-app'].includes(registerJs)) {
+              if (Array.isArray(entries['main-app'])) {
+                entries['main-app'].unshift(registerJs)
+              } else if (typeof entries['main-app'] === 'string') {
+                entries['main-app'] = [registerJs, entries['main-app']]
+              }
+            }
             return entries
           })
 


### PR DESCRIPTION
When using the new app directory in Next 13.1 a new main JS entry point is introduced, causing the PWA not to be installed.
This PR also adds the registration code to the Next 13.1 app entry point.