### PR TITLE
Make runtimeCache compatible with middleware

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -104,7 +104,17 @@ module.exports = [
     }
   },
   {
-    urlPattern: /\/_next\/data\/.+\/.+\.json$/i,
+    urlPattern: ({ url }) => {
+			if (self.origin !== url.origin) {
+				return false;
+			}
+
+			if (url.pathname.startsWith('/_next/data/') && url.pathname.indexOf('.json') !== -1) {
+				return true;
+			}
+
+			return false;
+		},
     handler: 'StaleWhileRevalidate',
     options: {
       cacheName: 'next-data',


### PR DESCRIPTION
Nextjs Middleware will include a querystring after .json like .json?breakpoint=xs