### PR TITLE
fix(next-auth): allow users to use application offline

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -133,7 +133,7 @@ module.exports = [
       // Exclude /api/auth/callback/* to fix OAuth workflow in Safari without impact other environment
       // Above route is default for next-auth, you may need to change it if your OAuth workflow has a different callback route
       // Issue: https://github.com/shadowwalker/next-pwa/issues/131#issuecomment-821894809
-      if (pathname.startsWith('/api/auth/')) return false
+      if (pathname.startsWith('/api/auth/callback/')) return false
       if (pathname.startsWith('/api/')) return true
       return false
     },


### PR DESCRIPTION
**Why:**
When a user is offline and runs an application, he will always be unauthorized. For my app, I temporarily changed the cache config and now suggest the same changes.

**What changed:**
- Update the list of URLs excluded from caching by making it more specific: `/api/auth/` => `/api/auth/callback/`.
- Google Auth is tested in _Chrome 112 arm64 for macOS_ and _Safari 16.2 for macOS_.
- Opening pages offline works fine, tested in the same browsers.
- Tested logging out when the user is online and the token is not valid.