### PR TITLE
Fixed a typo in `Offline Fallbacks` README.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Add the following into `_document.jsx` or `_app.tsx`, in `<Head>`:
 
 ## Offline Fallbacks
 
-Offline fallbacks are useful when the fetch failed from both cache and network, a precached resource is served instead of present an error from browser.
+Offline fallbacks are useful when fetching from both the cache and the network fails; a precached resource is served instead of presenting an error from the browser.
 
 To get started simply add a `/_offline` page such as `pages/_offline.js` or `pages/_offline.jsx` or `pages/_offline.ts` or `pages/_offline.tsx`. Then you are all set! When the user is offline, all pages which are not cached will fallback to '/\_offline'.
 


### PR DESCRIPTION
### Description

Fixed a typo in `Offline Fallbacks` README.md section by correcting:
* "fetch failed from both cache and network" to "fetching from both the cache and the network fails" for better readability and correct verb tense.
* "present an error from browser" to "presenting an error from the browser" to maintain parallel structure and correct the article usage.

### Motivation

This change improves the readability and accuracy of the documentation, ensuring that users have a clear and correct understanding of the content.

### Additional details
Direct ref can be found here: https://github.com/shadowwalker/next-pwa#offline-fallbacks